### PR TITLE
zope.proxy 7.2 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,7 +25,6 @@ requirements:
     - wheel
   run:
     - python
-    - setuptools
     - zope.interface
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "zope.proxy" %}
-{% set version = "7.0" %}
+{% set version = "7.2" %}
 
 package:
   name: {{ name|lower }}
@@ -7,11 +7,11 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name|replace(".", "_") }}-{{ version }}.tar.gz
-  sha256: 19cddee4b376ae9791fd6ddb491e861e3a7317a97b49a946b2e3c3f78254564c
+  sha256: a44ea34ced433dca665b5e8c300e83e40d2ae6821668f57aef38c11593e56f58
 
 build:
   number: 0
-  skip: True  # [py<39]
+  skip: true  # [py<39]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -2,7 +2,7 @@
 {% set version = "7.2" %}
 
 package:
-  name: {{ name|lower }}
+  name: {{ name }}
   version: {{ version }}
 
 source:
@@ -11,7 +11,7 @@ source:
 
 build:
   number: 0
-  skip: true  # [py<39]
+  skip: true  # [py<310]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:


### PR DESCRIPTION
zope.proxy 7.2 

**Destination channel:** Defaults

### Links

- [PKG-15767]
- dev_url:        https://github.com/zopefoundation/zope.proxy/tree/7.2
- conda_forge:    https://github.com/conda-forge/zope.proxy-feedstock
- pypi:           https://pypi.org/project/zope.proxy/7.2
- pypi inspector: https://inspector.pypi.io/project/zope.proxy/7.2

### Explanation of changes:

- new version number


[PKG-15767]: https://anaconda.atlassian.net/browse/PKG-15767?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ